### PR TITLE
Resolved issue #15 and added true iterator for efficient reading of records

### DIFF
--- a/examples/seq_reader.py
+++ b/examples/seq_reader.py
@@ -21,7 +21,7 @@ assert len(data) == 8
 count = nutchpy.sequence_reader.count(path)
 assert count == 8
 
-docs = nutchpy.sequence_reader.buffered_read(path)
+docs = nutchpy.sequence_reader.read_iterator(path)
 count2 = 0
 for doc in docs:
     count2 += 1

--- a/examples/seq_reader.py
+++ b/examples/seq_reader.py
@@ -10,7 +10,7 @@ assert len(data) == 5
 
 data = nutchpy.sequence_reader.slice(5,20,path)
 # print(data)
-assert len(data) == 2
+assert len(data) == 3
 
 #hadoop fs -text path <-- equivalent
 data = nutchpy.sequence_reader.read(path)
@@ -26,7 +26,7 @@ count2 = 0
 for doc in docs:
     count2 += 1
 
-assert count2 == count - 1 #FIXME: slice is skipping the first record https://github.com/ContinuumIO/nutchpy/issues/15
+assert count2 == count
 
 limit = 3
 docs = nutchpy.sequence_reader.read_all([path], limit=limit)

--- a/seqreader-app/src/main/java/com/continuumio/seqreaderapp/RecordIterator.java
+++ b/seqreader-app/src/main/java/com/continuumio/seqreaderapp/RecordIterator.java
@@ -1,0 +1,92 @@
+package com.continuumio.seqreaderapp;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.nutch.util.NutchConfiguration;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ *
+ * This iterator reads the sequence file as and when the records are consumed.
+ *
+ */
+public class RecordIterator implements Iterator<List<Writable>> {
+
+     private static final Configuration CONFIG = NutchConfiguration.create();
+    private SequenceFile.Reader reader;
+    private Writable key;
+    private Writable value;
+    private List<Writable> next;
+    private long numRecordsRead;
+    private long limit;
+
+
+    public RecordIterator(SequenceFile.Reader reader) throws IOException {
+        this(reader, 0, Long.MAX_VALUE);
+    }
+
+    /**
+     * Creates iterator for sequence file records
+     * @param reader The sequence file reader
+     * @param start The starting record number
+     * @param limit number of records to read
+     */
+    public RecordIterator(SequenceFile.Reader reader, long start,
+                          long limit) throws IOException {
+
+        this.reader = reader;
+        this.key = (Writable) ReflectionUtils.newInstance(
+                                                reader.getKeyClass(), CONFIG);
+        this.value = (Writable) ReflectionUtils.newInstance(
+                                                reader.getValueClass(), CONFIG);
+        this.limit = limit;
+
+        //skip rows till the start position ;
+        for(int i = 0; i < start && reader.next(key, value); i++);
+        this.next = readNext();
+    }
+
+    public boolean hasNext() {
+        return next != null;
+    }
+
+
+    /**
+     * gets Number of records read from the reader
+     * @return number of records read
+     */
+    public long getNumRecordsRead() {
+        return numRecordsRead;
+    }
+
+    private List<Writable> readNext() {
+        if (reader == null) {
+            throw new IllegalStateException("Reader is null");
+        }
+        try {
+            if (numRecordsRead < limit && reader.next(key, value)) {
+                numRecordsRead++;
+                return Arrays.asList(key, value);
+            } else {
+                //end of the reader or limit reached, close it and exit
+                reader.close();
+                reader = null;
+                return null;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<Writable> next() {
+        List<Writable> temp = next;
+        next = readNext();
+        return temp;
+    }
+}

--- a/seqreader-app/src/main/java/com/continuumio/seqreaderapp/SequenceReader.java
+++ b/seqreader-app/src/main/java/com/continuumio/seqreaderapp/SequenceReader.java
@@ -5,18 +5,10 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.*;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.nutch.scoring.webgraph.LinkDatum;
 import org.apache.nutch.util.NutchConfiguration;
-import py4j.GatewayServer;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 
 public class SequenceReader {
@@ -128,9 +120,6 @@ public class SequenceReader {
 
         List<List> rows=new ArrayList<List>();
 
-        Configuration conf = NutchConfiguration.create();
-        FileSystem fs = FileSystem.get(conf);
-
         Path file = new Path(path);
         System.out.println(file);
 
@@ -149,7 +138,6 @@ public class SequenceReader {
                 //hack JAVA tuple construction
                 //need to keep types simple for python conversion
                 List<String> t_row =new ArrayList<String>();
-
                 t_row.add(key.toString());
                 t_row.add(value.toString());
                 rows.add(t_row);
@@ -161,11 +149,39 @@ public class SequenceReader {
         return rows;
     }
 
+    /**
+     * Lazily reads the sequence file as and when the records are consumed from
+     * the returned iterator
+     * @param path path of sequence file
+     * @param start starting record number
+     * @return Iterator of Writable list which stores key and value in first two indices
+     * @throws IOException when an error occurs
+     */
+    public static RecordIterator getRecordIterator(String path, long start)
+            throws IOException {
+        return getRecordIterator(path, start, Long.MAX_VALUE);
+    }
+
+    /**
+     * Lazily reads the sequence file as and when the records are consumed from
+     * the returned iterator
+     * @param path - sequence file path
+     * @param start - the starting record number
+     * @param limit - number of records to read
+     * @return Iterator of Writable list which stores key and value in first two indices
+     * @throws IOException when an error occurs
+     */
+    public static RecordIterator getRecordIterator(
+            String path, long start, long limit) throws IOException{
+
+        Path file = new Path(path);
+        System.out.println("Creating document stream from : " + file);
+        SequenceFile.Reader reader = new SequenceFile.Reader(fs, file, conf);
+        return new RecordIterator(reader, start, limit);
+    }
+
     public static long count(String path) throws IOException  {
         //read rows between start and stop
-
-         Configuration conf = NutchConfiguration.create();
-        FileSystem fs = FileSystem.get(conf);
 
         Path file = new Path(path);
         System.out.println(file);
@@ -177,11 +193,8 @@ public class SequenceReader {
         Writable value = (Writable)
                 ReflectionUtils.newInstance(reader.getValueClass(), conf);
 
-
         //skip rows
         long i = 0;
-
-
         while(reader.next(key, value)) {
             i += 1;
         }

--- a/seqreader-app/src/test/java/com/continuumio/seqreaderapp/SequenceReaderTest.java
+++ b/seqreader-app/src/test/java/com/continuumio/seqreaderapp/SequenceReaderTest.java
@@ -20,4 +20,30 @@ public class SequenceReaderTest extends TestCase {
         List head = SequenceReader.head(2, testFilePath);
         assertEquals(head.get(0), slice.get(0));
     }
+
+    public void testGetRecordStream() throws Exception {
+        RecordIterator iterator =
+                SequenceReader.getRecordIterator(testFilePath, 0);
+        int count = 0;
+        while (iterator.hasNext()){
+            iterator.next();
+            count++;
+        }
+        assertEquals(count, iterator.getNumRecordsRead());
+        assertEquals(NUM_TEST_RECS, count);
+    }
+
+    public void testGetRecordStream1() throws Exception {
+        int start = 2;
+        int limit = 5;
+        RecordIterator iterator = SequenceReader.getRecordIterator(testFilePath,
+                start, limit);
+        int count = 0;
+        while (iterator.hasNext()){
+            iterator.next();
+            count++;
+        }
+        assertEquals(count, iterator.getNumRecordsRead());
+        assertEquals(limit, count);
+    }
 }

--- a/seqreader-app/src/test/java/com/continuumio/seqreaderapp/SequenceReaderTest.java
+++ b/seqreader-app/src/test/java/com/continuumio/seqreaderapp/SequenceReaderTest.java
@@ -1,0 +1,23 @@
+package com.continuumio.seqreaderapp;
+
+import junit.framework.TestCase;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Created by tg on 9/25/15.
+ */
+public class SequenceReaderTest extends TestCase {
+
+    private static File testFile = new File("../nutchpy/ex_data/crawldb_data");
+    private static String testFilePath = testFile.getAbsolutePath();
+    public static final int NUM_TEST_RECS = 8;
+
+    public void testSlice() throws Exception {
+        List slice = SequenceReader.slice(0, 2, testFilePath);
+        assertTrue(slice.size() == 2);
+        List head = SequenceReader.head(2, testFilePath);
+        assertEquals(head.get(0), slice.get(0));
+    }
+}


### PR DESCRIPTION
+ The issue #15 is resolved. `slice()` method is now proper
+ `RecordIterator`, a real iterator in java is added to efficiently read records( the subsequent calls to `slice()` has heavy disk seek overhead as it has to skip records till the start position for each call).
+ Test case  `SequenceReaderTest` is added 